### PR TITLE
Added keyboardtype to postalCode and name fields to solve caps bug

### DIFF
--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -248,6 +248,7 @@ const POSTAL_CODE_INPUT_WIDTH = 70; // https://github.com/yannickcr/eslint-plugi
               <View style={s.rowItem}>
                 <CCInput
                   {...this._inputProps("postalCode")}
+                  keyboardType={Platform.OS === 'ios' ? 'default' : 'visible-password'}
                   containerStyle={[s.inputContainer, inputContainerStyle]}
                 />
               </View>
@@ -256,6 +257,7 @@ const POSTAL_CODE_INPUT_WIDTH = 70; // https://github.com/yannickcr/eslint-plugi
               <View style={s.rowItem}>
                 <CCInput
                   {...this._inputProps("name")}
+                  keyboardType={Platform.OS === 'ios' ? 'default' : 'visible-password'}
                   containerStyle={[s.inputContainer, inputContainerStyle]}
                 />
               </View>
@@ -266,3 +268,4 @@ const POSTAL_CODE_INPUT_WIDTH = 70; // https://github.com/yannickcr/eslint-plugi
     );
   }
 }
+


### PR DESCRIPTION
There is a bug on Android that when you type in a text field and capitalize the characters, the string gets duplicated. This can be fixed somehow by adding this to the keyboardType prop of the input text fields. 
`keyboardType={Platform.OS === 'ios' ? 'default' : 'visible-password'}`

Further information in this thread: https://github.com/facebook/react-native/issues/11068